### PR TITLE
Fix measurement calculation time

### DIFF
--- a/bmp3.c
+++ b/bmp3.c
@@ -1948,7 +1948,7 @@ static int8_t get_odr_filter_settings(struct bmp3_dev *dev)
 static int8_t validate_osr_and_odr_settings(const struct bmp3_dev *dev)
 {
     int8_t rslt;
-    uint16_t meas_t = 0;
+    uint16_t meas_t = 234;
 
     /* Odr values in milli secs  */
     uint32_t odr[18] = {


### PR DESCRIPTION
According to BMP388 datasheet at Section 3.9.2. "Measurement rate in
forced mode and normal mode" there is also the constant of 234us to be
considered in the sum.