### PR TITLE
Remove superfluous check from null_ptr_check

### DIFF
--- a/bmp3.c
+++ b/bmp3.c
@@ -2560,8 +2560,7 @@ static int8_t null_ptr_check(const struct bmp3_dev *dev)
 {
     int8_t rslt;
 
-    if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_us == NULL) ||
-        (dev->intf_ptr == NULL))
+    if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_us == NULL))
     {
         /* Device structure pointer is not valid */
         rslt = BMP3_E_NULL_PTR;


### PR DESCRIPTION
The `null_ptr_check()` function checks that `dev.inft_ptr` is not NULL, however, nowhere in the code it this pointer used.
Indeed `dev.inf_ptr` is only used in user defined functions: `read`, `write` and `delay_us`...  hence if it is up to the user to use the pointer it should be up to the user to check it.

In the current state of things if the user doesn't want to use the pointer he would still have to assign it a value in order to pass the init, which is, imo, a bad practice.

Thus removing the check makes sense. 